### PR TITLE
Show contract address in output for --contract option

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,9 +24,6 @@ var argv = require('yargs')
     .alias('l', 'log')
     .boolean('l')
     .describe('l', 'log output to file')
-    .alias('d', 'cc')
-    .string('d')
-    .describe('d', 'reverse contract')
     .help('h')
     .alias('h', 'help')
     .epilog('copyright 2017')
@@ -38,14 +35,7 @@ if (cluster.isMaster) {
         numWallets: argv.count ? argv.count : 1,
         isContract: argv.contract ? true : false,
         log: argv.log ? true : false,
-        cc: argv.cc,
         logFname: argv.log ? 'VanityEth-log-' + Date.now() + '.txt' : ''
-    }
-    console.log(args.cc);
-    console.log('tf');
-    if (args.cc) {
-        console.log(VanityEth.getDeterministicContractAddress(argv.cc));
-        process.exit(0);
     }
     if (!VanityEth.isValidHex(args.input)) {
         console.error(args.input + ' is not valid hexadecimal');

--- a/index.js
+++ b/index.js
@@ -24,6 +24,9 @@ var argv = require('yargs')
     .alias('l', 'log')
     .boolean('l')
     .describe('l', 'log output to file')
+    .alias('d', 'cc')
+    .string('d')
+    .describe('d', 'reverse contract')
     .help('h')
     .alias('h', 'help')
     .epilog('copyright 2017')
@@ -35,7 +38,14 @@ if (cluster.isMaster) {
         numWallets: argv.count ? argv.count : 1,
         isContract: argv.contract ? true : false,
         log: argv.log ? true : false,
+        cc: argv.cc,
         logFname: argv.log ? 'VanityEth-log-' + Date.now() + '.txt' : ''
+    }
+    console.log(args.cc);
+    console.log('tf');
+    if (args.cc) {
+        console.log(VanityEth.getDeterministicContractAddress(argv.cc));
+        process.exit(0);
     }
     if (!VanityEth.isValidHex(args.input)) {
         console.error(args.input + ' is not valid hexadecimal');

--- a/libs/VanityEth.js
+++ b/libs/VanityEth.js
@@ -19,7 +19,6 @@ var isValidVanityWallet = function(wallet, input, isChecksum, isContract) {
     if (isContract) {
         var _contractAdd = getDeterministicContractAddress(_add);
         _contractAdd = isChecksum ? ethUtils.toChecksumAddress(_contractAdd) : _contractAdd;
-        wallet.contract = _contractAdd;
         return _contractAdd.substr(2, input.length) == input
     }
     _add = isChecksum ? ethUtils.toChecksumAddress(_add) : _add;
@@ -39,5 +38,6 @@ var getDeterministicContractAddress = function(address) {
 module.exports = {
     getVanityWallet: getVanityWallet,
     isValidHex: isValidHex,
+    getDeterministicContractAddress: getDeterministicContractAddress,
     ERRORS: ERRORS
 }

--- a/libs/VanityEth.js
+++ b/libs/VanityEth.js
@@ -19,6 +19,7 @@ var isValidVanityWallet = function(wallet, input, isChecksum, isContract) {
     if (isContract) {
         var _contractAdd = getDeterministicContractAddress(_add);
         _contractAdd = isChecksum ? ethUtils.toChecksumAddress(_contractAdd) : _contractAdd;
+        wallet.contract = _contractAdd;
         return _contractAdd.substr(2, input.length) == input
     }
     _add = isChecksum ? ethUtils.toChecksumAddress(_add) : _add;
@@ -38,6 +39,5 @@ var getDeterministicContractAddress = function(address) {
 module.exports = {
     getVanityWallet: getVanityWallet,
     isValidHex: isValidHex,
-    getDeterministicContractAddress: getDeterministicContractAddress,
     ERRORS: ERRORS
 }

--- a/libs/VanityEth.js
+++ b/libs/VanityEth.js
@@ -17,7 +17,7 @@ var isValidHex = function(hex) {
 var isValidVanityWallet = function(wallet, input, isChecksum, isContract) {
     var _add = wallet.address;
     if (isContract) {
-        var _contractAdd = getDeteministicContractAddress(_add);
+        var _contractAdd = getDeterministicContractAddress(_add);
         _contractAdd = isChecksum ? ethUtils.toChecksumAddress(_contractAdd) : _contractAdd;
         return _contractAdd.substr(2, input.length) == input
     }
@@ -32,11 +32,12 @@ var getVanityWallet = function(input = '', isChecksum = false, isContract = fals
     if (isChecksum) _wallet.address = ethUtils.toChecksumAddress(_wallet.address);
     return _wallet;
 }
-var getDeteministicContractAddress = function(address) {
+var getDeterministicContractAddress = function(address) {
     return '0x' + ethUtils.sha3(ethUtils.rlp.encode([address, 0])).slice(12).toString('hex');
 }
 module.exports = {
     getVanityWallet: getVanityWallet,
     isValidHex: isValidHex,
+    getDeterministicContractAddress: getDeterministicContractAddress,
     ERRORS: ERRORS
 }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,10 @@
     ],
     "author": "kvhnuke",
     "contributors": [
-        { "name" : "Boris K", "url" : "https://github.com/bokub"}
+        {
+            "name": "Boris K",
+            "url": "https://github.com/bokub"
+        }
     ],
     "license": "MIT",
     "bugs": {


### PR DESCRIPTION
This fixes a spelling mistake ("deterministic") and also adds contract address to the output when the `--contract` parameter is supplied.
The change to the package.json file occurred during `npm install` and I suspect will happen every time.

Tested by running with and without --contract.